### PR TITLE
Fix a bug that will cause terminated-buffers to all read

### DIFF
--- a/binary.lisp
+++ b/binary.lisp
@@ -271,7 +271,9 @@ specified BYTE-ORDER, then writes out the BUFFER."
   (aref arr (decf (fill-pointer arr))))
 
 (defun make-simple-array (complex-arr element-type)
-  (make-array (length complex-arr) :element-type element-type))
+  (make-array (length complex-arr)
+	      :element-type element-type
+	      :initial-contents complex-arr))
 
 (defun read-terminated-string (stream &key (terminator (buffer 0)))
   "Reads a string ending in the byte sequence specified by TERMINATOR. The TERMINATOR is

--- a/test/basic-test.lisp
+++ b/test/basic-test.lisp
@@ -147,7 +147,8 @@
   (let ((terminated-buffer (make-with-terminated-buffer)))
     (test-round-trip "TERMINATED-BUFFER TEST"
 		     (write-binary terminated-buffer *standard-output*)
-		     (read-binary 'with-terminated-buffer *standard-input*))))
+		     (assert-equal terminated-buffer
+				   (read-binary 'with-terminated-buffer *standard-input*)))))
 
 (defun run-test ()
   (terminated-buffer-test)


### PR DESCRIPTION
as empty. Also fix the test that caused this to be missed.