### PR TITLE
[tests] Make the tests an ASDF system, and have LISP-BINARY

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,13 @@
 It's not a good idea to run the `run-tests` script locally. It assumes it's okay to do things like `rm -rf ~/quicklisp`, 
 which is quite okay to do in the Docker environment it was designed for.
 
-Instead, evaluate `(load "basic-tests.lisp")` from your Lisp and then call `(lisp-binary-test::run-test)`.
+Instead, evaluate this:
+
+```
+(push '*default-pathname-defaults* asdf:*central-registry*)
+(ql:quickload :lisp-binary-tests)
+(lisp-binary-test::run-test)
+```
+
+Make sure your Lisp's `*default-pathname-defaults*` points to the test directory,
+or else try using a variable that does point there.

--- a/test/basic-test.lisp
+++ b/test/basic-test.lisp
@@ -1,10 +1,18 @@
 (defpackage :lisp-binary-test
-  (:use :common-lisp :lisp-binary))
+  (:use :common-lisp :lisp-binary :unit-test))
 
 (in-package :lisp-binary-test)
 
-(load "unit-test")
-(use-package :unit-test)
+(declaim (optimize (debug 3) (safety 3) (speed 0)))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defmacro assert= (x y)
+    (let ((x* (gensym "X"))
+	  (y* (gensym "Y")))
+      `(let ((,x* ,x)
+	     (,y* ,y))
+	 (or (= ,x* ,y*)
+	     (error "~S != ~S" ,x* ,y*))))))
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -24,10 +32,7 @@
 	 (or (equalp ,x* ,y*)
 	     (error "~S is not EQUAL to ~S" ,x* ,y*))))))
 
-(load "single-field-tests")
 
-
-(declaim (optimize (debug 3) (safety 3) (speed 0)))
 
 (defbinary other-binary ()
   (x 1 :type (unsigned-byte 1))
@@ -107,16 +112,6 @@
 		     (write-binary simple-binary *standard-output*)
 		     (let ((input-binary (read-binary 'simple-binary *standard-input*)))
 		       (assert-equal simple-binary input-binary)))))
-
-(defconstant +round-trip-test-parameters+
-  `((octuple-precision-floating-point-test
-     (0 1/2 1/3)
-     'octuple-float)
-    ((quad-precision-floating-point-test
-      (0 1/2 1/3)
-      'quadruple-float))
-    ((double-precision-floating-point-test
-      (0.0d0 0.5d0 0.33333333d0)))))
 
 (unit-test 'octuple-precision-floating-point-test ()
   (test-round-trip "OCTUPLE PRECISION FLOATING POINT TEST"

--- a/test/lisp-binary-test.asd
+++ b/test/lisp-binary-test.asd
@@ -1,0 +1,10 @@
+(asdf:defsystem :lisp-binary-test
+  :author ("Jeremy Phelps")
+  :version "1"
+  :license "GPLv3"
+  :description  "Test the LISP-BINARY system."
+  :depends-on (:lisp-binary)
+  :components
+  ((:file "unit-test")
+    (:file "basic-test" :depends-on ("unit-test"))
+    (:file "single-field-tests" :depends-on ("basic-test"))))

--- a/test/run-tests.lisp
+++ b/test/run-tests.lisp
@@ -1,11 +1,10 @@
 (format t "~%>>>>>>>>>>> Test program loading~%")
 (load "init.lisp")
 (format t "~%>>>>>>>>>>>>> Loaded init file~%")
-(ql:quickload :lisp-binary)
-(format t "~%>>>>>>>> LISP-BINARY library successfully loaded~%")
-(load "basic-test.lisp")
-
-(format t "~%>>>>>>>>>> Test program successfully loaded~%")
+(ql:quickload :asdf)
+(push '*default-pathname-defaults* asdf:*central-registry*)
+(ql:quickload :lisp-binary-test)
+(format t "~%>>>>>>>> LISP-BINARY test system successfully loaded~%")
 
 (lisp-binary-test::run-test)
 #+sbcl (exit)

--- a/test/single-field-tests.lisp
+++ b/test/single-field-tests.lisp
@@ -1,14 +1,5 @@
 (in-package :lisp-binary-test)
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (defmacro assert= (x y)
-    (let ((x* (gensym "X"))
-	  (y* (gensym "Y")))
-      `(let ((,x* ,x)
-	     (,y* ,y))
-	 (or (= ,x* ,y*)
-	     (error "~S != ~S" ,x* ,y*))))))
-
 (unit-test 'read/write-integer-test
   (let* ((integer 2948)
 	 (le-buffer (flexi-streams:with-output-to-sequence (out)


### PR DESCRIPTION
[tests] Make the tests an ASDF system, and have LISP-BINARY be a dependency of it.

This will tell us if the hack I put in to upgrade ASDF if necessary actually works.