### PR TITLE
When a reader function doesn't return the expected values, have

### DIFF
--- a/test/basic-test.lisp
+++ b/test/basic-test.lisp
@@ -190,6 +190,12 @@
 					 (read-binary 'multi-byte-bit-fields
 						      *standard-input*))))))
 
+;; I wrote a program that generated a bunch of warnings. This
+;; should be enough to reproduce it.
+
+(defbinary packet ()
+  (data (buffer) :type (counted-buffer 32)))
+
 (unit-test 'implicit-bit-stream-test
   (let ((struct (make-implicit-bit-stream)))
     (loop for *byte-order* in '(:little-endian :big-endian)


### PR DESCRIPTION

When a reader function doesn't return the expected values, have
the restart cases return the right value to pass the typechecker
in the latest version of SBCL without generating any warnings.
