### PR TITLE
Support an option to not load the bundled version of ASDF even

### DIFF
--- a/lisp-binary.asd
+++ b/lisp-binary.asd
@@ -1,3 +1,4 @@
+#-lisp-binary/never-use-own-asdf
 (let ((asdf-version (when (find-package :asdf)
                       (let ((ver (symbol-value
                                   (or (find-symbol (string :*asdf-version*) :asdf)
@@ -22,7 +23,8 @@
   :components
   ((:file "binary-1" :depends-on ("utils" "float" "integer" "simple-bit-stream" "reverse-stream"))
    (:file "binary-2" :depends-on ("utils" "float" "integer" "simple-bit-stream" "reverse-stream" "binary-1"))
-   #+lisp-binary-upgrade-asdf (:file "asdf")
+   #+(and lisp-binary-upgrade-asdf
+	  (not lisp-binary/never-use-own-asdf)) (:file "asdf")
    (:file "simple-bit-stream" :depends-on ("integer"))
    (:file "reverse-stream" :depends-on ("integer"))
    (:file "integer" :depends-on ("utils"))

--- a/test/run-tests
+++ b/test/run-tests
@@ -5,6 +5,10 @@ set -x -e -o pipefail
 cd `dirname $0`
 base_dir=`pwd`
 
+pushd /etc/apt/sources.list.d
+sudo rm -f pgdg.list
+popd
+
 (yes || true) | (
 sudo apt-get update
 sudo apt-get install wget --yes


### PR DESCRIPTION
if it seems necessary.

Addresses #30. If `:lisp-binary/never-use-own-asdf` is found in `CL:*FEATURES*`, then the logic to use the bundled copy of ASDF will not be read.

This will result in Lisp-Binary failing to load on systems with a default version of ASDF below 3.1.5.
