### PR TITLE
Test with latest sbcl

### DIFF
--- a/binary-1.lisp
+++ b/binary-1.lisp
@@ -617,7 +617,7 @@ that would normally be bound must be added with a LET form."
 			(offset 0 :type integer)
 			(type nil :type symbol)
 			(base-pointer :beginning :type keyword)
-			(stream *standard-input* :type keyword)))
+			(stream *standard-input* :type stream)))
 
 (defstruct out-pointer
   (offset-position 0 :type number)

--- a/test/run-tests
+++ b/test/run-tests
@@ -14,7 +14,7 @@ sudo apt-get update
 sudo apt-get install wget --yes
 sudo apt-get install clisp --yes
 sudo apt-get install make --yes
-wget -O $HOME/sbcl.tar.bz2 'http://prdownloads.sourceforge.net/sbcl/sbcl-1.4.13-x86-64-linux-binary.tar.bz2'
+wget -O $HOME/sbcl.tar.bz2 'https://astuteinternet.dl.sourceforge.net/project/sbcl/sbcl/1.5.9/sbcl-1.5.9-source.tar.bz2'
 wget -O $HOME/ccl.tar.gz 'https://github.com/Clozure/ccl/releases/download/v1.11/ccl-1.11-linuxx86.tar.gz'
 )
 

--- a/test/run-tests
+++ b/test/run-tests
@@ -24,7 +24,7 @@ wget -O $HOME/ccl.tar.gz 'https://github.com/Clozure/ccl/releases/download/v1.11
  cd 
  tar -xzf ccl.tar.gz
  tar -xjf sbcl.tar.bz2
- cd sbcl-1.4.13-x86-64-linux
+ cd sbcl-1.5.9-x86-64-linux
  sudo ./install.sh
 )
 

--- a/test/run-tests
+++ b/test/run-tests
@@ -10,12 +10,13 @@ sudo rm -f pgdg.list
 popd
 
 (yes || true) | (
-sudo apt-get update
-sudo apt-get install wget --yes
-sudo apt-get install clisp --yes
-sudo apt-get install make --yes
-wget -O $HOME/sbcl.tar.bz2 'https://astuteinternet.dl.sourceforge.net/project/sbcl/sbcl/1.5.9/sbcl-1.5.9-source.tar.bz2'
-wget -O $HOME/ccl.tar.gz 'https://github.com/Clozure/ccl/releases/download/v1.11/ccl-1.11-linuxx86.tar.gz'
+    sudo apt-get update
+    sudo apt-get install sbcl --yes
+    sudo apt-get install wget --yes
+    sudo apt-get install clisp --yes
+    sudo apt-get install make --yes
+    wget -O $HOME/sbcl.tar.bz2 'https://astuteinternet.dl.sourceforge.net/project/sbcl/sbcl/1.5.9/sbcl-1.5.9-source.tar.bz2'
+    wget -O $HOME/ccl.tar.gz 'https://github.com/Clozure/ccl/releases/download/v1.11/ccl-1.11-linuxx86.tar.gz'
 )
 
 
@@ -24,8 +25,10 @@ wget -O $HOME/ccl.tar.gz 'https://github.com/Clozure/ccl/releases/download/v1.11
  cd 
  tar -xzf ccl.tar.gz
  tar -xjf sbcl.tar.bz2
- cd sbcl-1.5.9-x86-64-linux
+ cd sbcl-1.5.9
+ ./make.sh
  sudo ./install.sh
+ sudo apt-get remove sbcl
 )
 
 export base_dir


### PR DESCRIPTION
Zach Beane reported that this library does not build without warnings on the latest version of SBCL. Therefore, let's update the version of SBCL that is used for running the test suite so that I can catch new problems.