### PR TITLE
Fix READ-SEQUENCE behavior on bit streams.

### DIFF
--- a/test/single-field-tests.lisp
+++ b/test/single-field-tests.lisp
@@ -106,3 +106,14 @@
 	  (end-of-file ()
 	    :pass)))))
 	 
+
+(unit-test 'read-sequence-bit-stream-test
+    (flexi-streams:with-input-from-sequence (in #(155))
+      (with-wrapped-in-bit-stream (in-bitstream in)
+	(read-bytes 1/2 in-bitstream)
+	(let ((seq (make-array 1)))
+	  (assert-equalp
+	   (read-sequence seq in-bitstream)
+	   0)))))
+	
+      


### PR DESCRIPTION
The last PR introduced a bug in that READ-SEQUENCE on a BIT-STREAM will signal an error on EOF, which is contrary to what a normal call to READ-SEQUENCE does. This PR fixes that problem.