### PR TITLE
Allow ENUM types to have custom readers and writers.

### DIFF
--- a/test/type-field-expansion-tests.lisp
+++ b/test/type-field-expansion-tests.lisp
@@ -17,13 +17,8 @@
      ,@body))
 
 (defmacro with-write-stream-to-buffer (&body body)
-  `(progn
-     (with-open-binary-file (*stream* "/tmp/foobar.bin"
-				      :direction :output
-				      :if-exists :supersede)
-       ,@body)
-     (with-open-binary-file (in "/tmp/foobar.bin")
-       (read-binary-type `(simple-array (unsigned-byte 8) (,(file-length in))) in))))
+  `(flexi-streams:with-output-to-sequence (*stream*)
+     ,@body))
 
 (defun expand-defbinary-field (default-value &rest keys)
   (apply #'lisp-binary::expand-defbinary-field (list* '*field* default-value


### PR DESCRIPTION
This is needed to be able to use Lisp-Binary enums
to read Minecraft [particle IDs](https://wiki.vg/Protocol#Particle), 
which are enums represented by a [Minecraft-specific integer type](https://wiki.vg/Protocol#VarInt_and_VarLong) that requires a custom reader and writer.

The `define-enum` form is also extended to allow `:signed-representation` to be
specified instead of always using the default value of `:twos-complement`.