### PR TITLE
Fix a bug stemming from trying to push quasiquoting too far.

### DIFF
--- a/binary-1.lisp
+++ b/binary-1.lisp
@@ -848,7 +848,7 @@ bindings of all the relevant special variables."
 DEFBINARY macro."
   (read/write-binary-type :write type stream :byte-order byte-order
 			  :value (if (symbolp value)
-				     `',value
+				     (list 'quote value)
 				     value)
 			  :align align :element-align element-align))
 


### PR DESCRIPTION
A bug made it into Quicklisp: Using the EVAL type specifier can result in a reference to an undefined variable named `LISP-BINARY::VALUE`. This PR fixes that bug.