### PR TITLE
Make it possible to avoid using CFFI and force arithmetic encoding/decoding of floats.

### DIFF
--- a/float.lisp
+++ b/float.lisp
@@ -314,8 +314,7 @@ is 24."
 
 
 (defun make-smallest-denormal (format result-type)
-    "FIXME: The actual smallest denormal for :SINGLE should be 2^-149, not 2^-127. I have no idea how to derive that value,
-so I don't know what it should be for other types, nor what the largest denormal value should be."
+    "FIXME: I don't know what the largest denormal value should be."
     (decode-float-bits 1 :format format :result-type result-type))
   
   (defun make-largest-denormal (format result-type)

--- a/lisp-binary.asd
+++ b/lisp-binary.asd
@@ -19,7 +19,7 @@
   :license "GPLv3"
   :description  "Declare binary formats as structs and then read and write them."
   :depends-on (:closer-mop :moptilities :flexi-streams :quasiquote-2.0
-			   :cffi)
+			   :alexandria #-lisp-binary/no-cffi :cffi)
   :components
   ((:file "binary-1" :depends-on ("utils" "float" "integer" "simple-bit-stream" "reverse-stream"))
    (:file "binary-2" :depends-on ("utils" "float" "integer" "simple-bit-stream" "reverse-stream" "binary-1"))

--- a/simple-bit-stream.lisp
+++ b/simple-bit-stream.lisp
@@ -120,7 +120,7 @@ can be discarded if BYTE-ALIGNED-P returns T."))
 (defmethod stream-read-byte ((stream bit-stream))
   (init-read stream)
   (cond ((= (slot-value stream 'bits-left) 0)
-	 (read-byte stream (slot-value stream 'real-stream)))
+	 (read-byte (slot-value stream 'real-stream)))
 	((= (slot-value stream 'bits-left)
 	    (slot-value stream 'element-bits))
 	 (prog1

--- a/test/single-field-tests.lisp
+++ b/test/single-field-tests.lisp
@@ -60,7 +60,7 @@
 	   (test-buffer (flexi-streams:with-output-to-sequence
 			    (out :element-type '(unsigned-byte 8))
 			  (write-binary-type test-value 'single-float out :byte-order :big-endian))))
-      (assert-equalp test-buffer (buffer 0 #x7f #xff #xff))
+      (assert-equalp test-buffer (buffer 0 #x40 0 0))
       (assert= (flexi-streams:with-input-from-sequence
 		   (in test-buffer)
 		 (read-binary-type 'single-float in :byte-order :big-endian))

--- a/types.lisp
+++ b/types.lisp
@@ -553,7 +553,8 @@
 						octuple-float octo-float) 'long-float)
 		      (otherwise 'number))))
     (values float-type
-	    `(read-float ,float-format :stream ,stream-symbol :byte-order ,byte-order)
+	    `(read-float ,float-format :stream ,stream-symbol :byte-order ,byte-order
+			 :result-type ',float-type)
 	    `(write-float ,float-format ,name :stream ,stream-symbol
 			  :byte-order ,byte-order))))
 


### PR DESCRIPTION
By default, single and double-precision floating point are encoded and decoded by writing the bits to memory and then using CFFI to make the hardware reinterpret that memory as floating point.

Lisp-Binary also implements arithmetic-based encoding and decoding for half, quadruple, and octuple precision floating point.

By pushing `:lisp-binary/no-cffi` to `*features*` before loading Lisp-Binary, you can build Lisp-Binary without the CFFI dependency. It will then use arithmetic encoding/decoding for all floating-point formats.

This PR also fixes some bugs that were found in the arithmetic encoder, and adds recovery from underflow errors under CLISP.