### PR TITLE
Fix loading on Clozure CL

### DIFF
--- a/simple-bit-stream.lisp
+++ b/simple-bit-stream.lisp
@@ -244,7 +244,7 @@ can be discarded if BYTE-ALIGNED-P returns T."))
 (defmethod
     #+ccl ccl:stream-read-vector
     #-ccl stream-read-sequence
-    (sequence (stream bit-stream) start end &key &allow-other-keys)
+    (sequence (stream bit-stream) start end #-ccl &key #-ccl &allow-other-keys)
   (%stream-read-sequence stream sequence start end))
 
 #+clisp


### PR DESCRIPTION
Fix the following error signaled by Clozure CL during the compilation of `simple-bit-stream.lisp`:


```
Lambda list of method #<STANDARD-METHOD CCL:STREAM-READ-VECTOR (T
                                                                BIT-STREAM
                                                                T
                                                                T)> 
is incompatible with that of the generic function CCL:STREAM-READ-VECTOR.
Method's lambda-list : (SEQUENCE STREAM START END &KEY
                        &ALLOW-OTHER-KEYS)
Generic-function's   : (TRIVIAL-GRAY-STREAMS::S
                        TRIVIAL-GRAY-STREAMS::SEQ
                        TRIVIAL-GRAY-STREAMS::START
                        TRIVIAL-GRAY-STREAMS::END)
```