### PR TITLE
binary-2.lisp => Changed: Renamed restart to avoid conflict with func…

### DIFF
--- a/binary-2.lisp
+++ b/binary-2.lisp
@@ -17,7 +17,7 @@
      do (handler-bind ((no-destructuring-match
 			(lambda (exn)
 			  (declare (ignore exn))
-			  (continue))))
+			  (invoke-restart 'continue-with-next-expander))))
 	  (restart-case
 	      (return (multiple-value-bind (type reader writer)
 			  (apply expander (cons type-info (let ((type (slot-value type-info 'type)))
@@ -33,7 +33,7 @@
 					       ,(slot-value type-info 'name)
 					       ,(slot-value type-info 'stream-symbol))
 				     writer))))
-	    (continue () nil)))
+	    (continue-with-next-expander () nil)))
        finally (error "Unknown LISP-BINARY type: ~s" (slot-value type-info 'type))))
 	  
 (defun defbinary-constructor-name (name defstruct-options)


### PR DESCRIPTION
In order to get macro `defbinary` to work correctly on AllegroCL 11 Enterprise Edition I needed to adapt calling a restart and the restart's name from `continue` to `continue-with-next-expander` to apparently avoid name conflicts with standard function `continue` ... At least it *does* work now...

Please review. Thanks! 