### PR TITLE
Add with-event-suite macro for defining families of defbinary structs.

### DIFF
--- a/binary-1.lisp
+++ b/binary-1.lisp
@@ -15,6 +15,7 @@ reading and writing integers and floating-point numbers. Also provides a bit-str
 	   :write-float
 	   
 	   :defbinary
+	   :with-event-suite
 
 	   :*byte-order*
 	   :base-pointer
@@ -1016,3 +1017,4 @@ WITH-SLOTS. These slots are described below:
 	       (apply 
 		(destructuring-lambda ,lambda-list ,@body) ,args)))
 	   *type-expanders*)))
+


### PR DESCRIPTION
Hey,

what do you think of adding something like this to the codebase? (I hope I added it in the right place)

What this macro does is create helper read/write functions for a set of `defbinary` definitions. It auto generates an enum with `define-enum`, then uses that to differentiate one `defbinary` from another. Binary serialization through the helper prepends a type identifier (a 2-byte integer), the enum member's value, and conversely, when deserializing, it reads 2 bytes to know which type to deserialize into.

I think technically the same could be achieved using EVAL type specifiers, but I'm not sure about nested `defbinary` structs (so one struct containing a field with the type of another struct). However, I find this way of doing `defbinary` for 'unions of structs' more straightforward. 